### PR TITLE
chore: fix ci build bug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,10 @@ commands:
         default: false
     steps:
       - run:
+          name: "Build package"
+          command: |
+            ${NODE_BIN_DIR}/lerna changed --include-dependencies build
+      - run:
           name: "Publish packages to NPM registry if needed"
           command: |
             ${NODE_BIN_DIR}/lerna publish from-package \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,10 +44,6 @@ commands:
         default: false
     steps:
       - run:
-          name: "Build package"
-          command: |
-            ${NODE_BIN_DIR}/lerna changed --include-dependencies build
-      - run:
           name: "Publish packages to NPM registry if needed"
           command: |
             ${NODE_BIN_DIR}/lerna publish from-package \

--- a/makefile
+++ b/makefile
@@ -13,14 +13,6 @@ build: check-dep
 	@echo "$(P) Run \`npm run build\` of all packages with \`scripts.build\`"
 	$(BIN_DIR)/lerna run --stream build
 
-clean-lib:
-	@echo "$(P) Clean lib/"
-	$(BIN_DIR)/rimraf lib/
-
-clean-dist:
-	@echo "$(P) Clean dist/"
-	$(BIN_DIR)/rimraf dist/
-
 changed-packages-unit-test:
 	@echo "$(P) Run tests of changed packages"
 	NODE_ENV=test $(BIN_DIR)/lerna run test --since --stream --include-merged-tags

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "dev": "make dev",
     "test": "make test",
-    "build": "make build"
+    "build": "make build",
+    "prepublishOnly": "make build"
   },
   "husky": {
     "hooks": {

--- a/packages/dual-channel/package.json
+++ b/packages/dual-channel/package.json
@@ -6,8 +6,7 @@
     "build": "make build",
     "clean": "make clean",
     "dev": "make dev",
-    "dev-server": "make dev-server",
-    "prepublishOnly": "make build"
+    "dev-server": "make dev-server"
   },
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/orangutan/package.json
+++ b/packages/orangutan/package.json
@@ -8,8 +8,7 @@
   "license": "MIT",
   "scripts": {
     "build": "make build",
-    "dev": "make dev",
-    "prepublishOnly": "make build"
+    "dev": "make dev"
   },
   "dependencies": {
     "@babel/polyfill": "^7.8.7",

--- a/packages/scrollable-image/package.json
+++ b/packages/scrollable-image/package.json
@@ -10,8 +10,7 @@
     "build": "make build",
     "clean": "make clean",
     "dev": "make dev",
-    "dev-server": "make dev-server",
-    "prepublishOnly": "make build"
+    "dev-server": "make dev-server"
   },
   "dependencies": {
     "@babel/polyfill": "^7.8.7",

--- a/packages/sheet2code-ui/package.json
+++ b/packages/sheet2code-ui/package.json
@@ -9,8 +9,7 @@
   "scripts": {
     "build": "make build",
     "dev": "make dev",
-    "dev-server": "make dev-server",
-    "prepublishOnly": "make build"
+    "dev-server": "make dev-server"
   },
   "devDependencies": {
     "react-dom": "^16.8.0"

--- a/packages/timeline/package.json
+++ b/packages/timeline/package.json
@@ -10,7 +10,6 @@
     "clean": "make clean",
     "build": "make build",
     "dev": "make dev",
-    "prepublishOnly": "make build",
     "dev-server": "make dev-server"
   },
   "devDependencies": {


### PR DESCRIPTION
Problem description:

When `@twreporter/orangutan` build its webpack bundle, it needs the `lib` files of its dependencies in the same monorepo (ex: `@twreporter/dual-channel`, `@twreporter/scrollable-image`). But in original CI process, only the packages with version bumping will be built.

Solution:

~Build all packages before testing and buming version~ (this will cause unnecessary building for commits like document update, version bumping...etc)

~Use `lerna changed` with [filter options](https://github.com/lerna/lerna/tree/master/core/filter-options#--include-dependencies) to build the dependencies package before publishing~ (see https://github.com/twreporter/orangutan-monorepo/pull/20#issuecomment-610315206 )

Use root `prepublishOnly` hook to build all packages before publishing instead. Ref: https://github.com/lerna/lerna/tree/master/commands/publish#lifecycle-scripts