### PR TITLE
refactor: remove `Sheets` from pkg entry file

### DIFF
--- a/packages/dual-channel/README.md
+++ b/packages/dual-channel/README.md
@@ -50,6 +50,22 @@ Option 2:
 import ReactComponent from '@twreporter/dual-channel/lib/app'
 ```
 
+## Import Sheets Class
+
+```
+import Sheets from '@twreporter/dual-channel/lib/sheets'
+
+const sheets = new Sheets({
+  spreadsheetId,
+  keyFile,
+  targetSheetsId,
+})
+```
+
+The reaseon why `Sheets` is not exported in `src/index.js` is because it imports `googleapis`.
+`googleapis` imports nodejs specific modules, which makes webpack build failure.
+Thus, we need to import `Sheets` directly from its file.
+
 ## Data
 
 ### Reproduce Demo Data
@@ -104,7 +120,7 @@ Besides createing service account, you also have to enable `Google Sheets API`.
 ## Build Embedded Code
 
 ```javascript
-import dualChannelUtils from '@twreporter/dual-channel'
+import Sheets from '@twreporter/dual-channel/lib/sheets'
 
 const sheets = new dualChannelUtils.Sheets({
   spreadsheetId: '1Ppisv4HTZHYMp95umgCoADNuP1PSkL-t9na-5lRIqSY',
@@ -135,10 +151,3 @@ $ cat spreadsheet-api-key-file.json | grep client_email
 ```
 
 and share your spreadsheet with your service account email.
-
-### Using webpack to bundle dual channel react component occurs errors
-
-You can adopt Option 2 described in https://github.com/twreporter/dual-channel#import-react-component
-
-In addition, you can add `target: 'node'` in your webpack config. (See https://webpack.js.org/concepts/targets/#usage)
-Adding `target: 'node'` prevents webpack from bundling nodejs built-in modules.

--- a/packages/dual-channel/src/index.js
+++ b/packages/dual-channel/src/index.js
@@ -1,11 +1,9 @@
 import ReactComponent from './app'
-import Sheets from './sheets'
 import path from 'path'
 import { buildEmbeddedCode } from './build-code'
 
 export default {
   ReactComponent,
-  Sheets,
   buildEmbeddedCode,
   getWebpackEntry: () => {
     return path.resolve(__dirname, './build-code/client.js')


### PR DESCRIPTION
@YuCJ 
I am wrong about `target:'node'` in this thread https://github.com/twreporter/orangutan-monorepo/pull/6#discussion_r397600275 .
Although `target:'node'` avoids webpack failure, however, the output files can not run on browser.

Because of `@twreporter/orangutan`, it imports `@twreporter/dual-channel` in [its entry file](https://github.com/twreporter/orangutan-monorepo/blob/master/packages/orangutan/src/index.js#L1).
`@twreporter/scrollable-image-ui` wants to webpack bundle `@twreporter/orangutan`.
It causes webpack bundle failures. 
Error message:
```
ERROR in /Users/nick/codes/@twreporter/orangutan/node_modules/gaxios/node_modules/https-proxy-agent/dist/agent.js
Module not found: Error: Can't resolve 'net' in '/Users/nick/codes/@twreporter/orangutan/node_modules/gaxios/node_modules/https-proxy-agent/dist'). 
 @ /Users/nick/codes/@twreporter/orangutan/node_modules/gaxios/node_modules/https-proxy-agent/dist/agent.js 15:30-44
 @ /Users/nick/codes/@twreporter/orangutan/node_modules/gaxios/node_modules/https-proxy-agent/dist/index.js
 @ /Users/nick/codes/@twreporter/orangutan/node_modules/gaxios/build/src/gaxios.js
 @ /Users/nick/codes/@twreporter/orangutan/node_modules/gaxios/build/src/index.js
 @ /Users/nick/codes/@twreporter/orangutan/node_modules/google-auth-library/build/src/transporters.js
 @ /Users/nick/codes/@twreporter/orangutan/node_modules/google-auth-library/build/src/index.js
 @ /Users/nick/codes/@twreporter/orangutan/node_modules/googleapis-common/build/src/index.js
 @ /Users/nick/codes/@twreporter/orangutan/node_modules/googleapis/build/src/googleapis.js
 @ /Users/nick/codes/@twreporter/orangutan/node_modules/googleapis/build/src/index.js
 @ ../dual-channel/lib/sheets/index.js
 @ ../dual-channel/lib/index.js
 @ ./node_modules/@twreporter/orangutan/lib/index.js
 @ ./src/components/embedded-code-modal.js
 @ ./src/components/app.js
 @ ./src/client.js
```
Currently, I have not found a better solution for this.
Hence, I adopt Option 2 (remove `Sheets` from pkg entry file) for further development.
