### PR TITLE
Fix babel config

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -4,18 +4,7 @@ const isTest = process.env.NODE_ENV === 'test'
 module.exports = {
   ignore: isTest ? [] : ['**/__test__/**/*'],
   presets: [
-    [
-      // follow https://babeljs.io/docs/en/babel-polyfill#usage-in-node-browserify-webpack
-      // to import `@babel/polyfill`
-      '@babel/preset-env',
-      {
-        useBuiltIns: 'usage',
-        corejs: {
-          version: 2,
-          proposals: true,
-        },
-      },
-    ],
+    '@babel/env',
     [
       '@babel/preset-react',
       {

--- a/dev/__test__/dependencies.test.js
+++ b/dev/__test__/dependencies.test.js
@@ -12,17 +12,6 @@ const _ = {
   forOwn,
 }
 
-describe('All packages should have some certain dependencies.', () => {
-  const dependencyVersionsOfPackages = utils.listDependencyVersionsByPackage(
-    dependencyTypeShorthands.prod
-  )
-  _.forOwn(dependencyVersionsOfPackages, (dependencies, pkg) => {
-    test(`\`${pkg}\` should have \`@babel/polyfill\` dependency`, () => {
-      expect(dependencies.hasOwnProperty('@babel/polyfill')).toBeTruthy()
-    })
-  })
-})
-
 describe('All prod dependencies should have valid intersection of its version ranges across different packages.', () => {
   const targetDepType = dependencyTypeShorthands.prod
   const dependencyVersionsByDependency = utils.listDependencyVersionsByDependency(

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@babel/core": "7.4.5",
     "@babel/node": "^7.5.5",
     "@babel/plugin-proposal-class-properties": "7.4.4",
-    "@babel/polyfill": "^7.8.7",
     "@babel/preset-env": "7.4.5",
     "@babel/preset-react": "7.0.0",
     "@commitlint/cli": "^8.2.0",

--- a/packages/dual-channel/package.json
+++ b/packages/dual-channel/package.json
@@ -11,7 +11,6 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "@babel/polyfill": "^7.8.7",
     "@rematch/core": "^1.0.6",
     "@twreporter/errors": "^1.1.0",
     "googleapis": "^47.0.0",

--- a/packages/orangutan/package.json
+++ b/packages/orangutan/package.json
@@ -11,7 +11,6 @@
     "dev": "make dev"
   },
   "dependencies": {
-    "@babel/polyfill": "^7.8.7",
     "@twreporter/dual-channel": "^2.1.0-rc.5",
     "@twreporter/scrollable-image": "^1.1.0-rc.4"
   },

--- a/packages/scrollable-image-ui/package.json
+++ b/packages/scrollable-image-ui/package.json
@@ -7,7 +7,6 @@
     "dev": "make dev"
   },
   "dependencies": {
-    "@babel/polyfill": "^7.8.7",
     "@material-ui/core": "^4.9.7",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.47",

--- a/packages/scrollable-image/package.json
+++ b/packages/scrollable-image/package.json
@@ -13,7 +13,6 @@
     "dev-server": "make dev-server"
   },
   "dependencies": {
-    "@babel/polyfill": "^7.8.7",
     "prop-types": "^15.0.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",

--- a/packages/sheet2code-ui/package.json
+++ b/packages/sheet2code-ui/package.json
@@ -15,7 +15,6 @@
     "react-dom": "^16.8.0"
   },
   "dependencies": {
-    "@babel/polyfill": "^7.8.7",
     "@material-ui/core": "^4.9.5",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.46",

--- a/packages/timeline/package.json
+++ b/packages/timeline/package.json
@@ -17,7 +17,6 @@
     "react-dom": "^16.8.0"
   },
   "dependencies": {
-    "@babel/polyfill": "^7.8.7",
     "@twreporter/core": "^1.2.0",
     "@twreporter/errors": "^1.1.0",
     "lodash": "^4.17.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -769,14 +769,6 @@
     "@babel/helper-create-regexp-features-plugin" "^7.8.3"
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/polyfill@^7.8.7":
-  version "7.8.7"
-  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.8.7.tgz#151ec24c7135481336168c3bd8b8bf0cf91c032f"
-  integrity sha512-LeSfP9bNZH2UOZgcGcZ0PIHUt1ZuHub1L3CVmEyqLxCeDLm4C5Gi8jRH8ZX2PNpDhQCo0z6y/+DIs2JlliXW8w==
-  dependencies:
-    core-js "^2.6.5"
-    regenerator-runtime "^0.13.4"
-
 "@babel/preset-env@7.4.5":
   version "7.4.5"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.4.5.tgz#2fad7f62983d5af563b5f3139242755884998a58"
@@ -4104,7 +4096,7 @@ core-js-compat@^3.1.1, core-js-compat@^3.6.2:
     browserslist "^4.8.3"
     semver "7.0.0"
 
-core-js@^2.4.0, core-js@^2.5.0, core-js@^2.6.5:
+core-js@^2.4.0, core-js@^2.5.0:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==


### PR DESCRIPTION
### Problem Description
As @taylrj found out, those es5 files (transpiled according to this `babel.config.js`) can not be bundled by webpack.
Even though webpack can build the bundles without any errors and warning, however, the browser will throw error like following one
```
Uncaught ReferenceError: exports is not defined
```

I revert this change for further development.

I will spend time digging it out, and see what is the root cause.
