### PR TITLE
fix(scrollable-image): avoid extraneous onLeave event

### DIFF
--- a/packages/scrollable-image/src/components/scroll-horizontal.js
+++ b/packages/scrollable-image/src/components/scroll-horizontal.js
@@ -14,6 +14,7 @@ const _ = {
 
 const Container = styled.div`
   overflow: hidden;
+  min-height: 100vh;
 `
 
 const Wrapper = styled.div`


### PR DESCRIPTION
### Problem Description

test page: https://keystone-preview.twreporter.org/a/test-scrollableimage

After images are loaded, [_handleBottomBoundaryLeave](https://github.com/twreporter/orangutan-monorepo/blob/d9bd773be6587fcd08c4f395d45f62c712cd0b6f/packages/scrollable-image/src/components/with-waypoints.js#L74) will be triggered and set `isActive` to be true.

The component's `position` will be `fixed` once `scroll` event is dispatched.  

### Solution
This patch adds min-height to scrollable-image component to avoid
triggering `onLeave` event after images are loaded.