### PR TITLE
chore(timeline): add migration tools

### DIFF
--- a/packages/timeline/dev/delete.js
+++ b/packages/timeline/dev/delete.js
@@ -1,0 +1,21 @@
+import * as google from '../src/migrations/utils/google-services'
+import path from 'path'
+
+const fileId = process.env.ID
+const keyFile =
+  process.env.KEY_FILE || path.resolve(__dirname, './sheets-api.json')
+const driveService = google.drive(
+  google.auth({
+    keyFile,
+    scopes: ['https://www.googleapis.com/auth/drive'],
+  })
+)
+
+console.log('Start deleting file: ', fileId)
+driveService.files
+  .delete({
+    fileId,
+  })
+  .then(() => {
+    console.log('file deleted')
+  })

--- a/packages/timeline/dev/migrate.js
+++ b/packages/timeline/dev/migrate.js
@@ -21,13 +21,7 @@ switch (fromTo) {
         scopes: ['https://www.googleapis.com/auth/spreadsheets'],
       })
     )
-    migrate({ sheetsService, driveService }, sourceSpreadsheetId).then(
-      newSpreadsheet => {
-        console.log('You can run the command:')
-        console.log(`ID=${newSpreadsheet} make delete-spreadsheet`)
-        console.log('to delete the new spreadsheet.')
-      }
-    )
+    migrate({ sheetsService, driveService }, sourceSpreadsheetId)
     break
   }
   default:

--- a/packages/timeline/dev/migrate.js
+++ b/packages/timeline/dev/migrate.js
@@ -1,0 +1,41 @@
+import * as google from '../src/migrations/utils/google-services'
+import migrate from '../src/migrations/v0-to-v2'
+import path from 'path'
+
+const fromTo = process.env.FROM_TO
+const sourceSpreadsheetId = process.env.SOURCE
+const keyFile =
+  process.env.KEY_FILE || path.resolve(__dirname, './sheets-api.json')
+
+switch (fromTo) {
+  case 'v0-to-v2': {
+    const driveService = google.drive(
+      google.auth({
+        keyFile,
+        scopes: ['https://www.googleapis.com/auth/drive'],
+      })
+    )
+    const sheetsService = google.sheets(
+      google.auth({
+        keyFile,
+        scopes: ['https://www.googleapis.com/auth/spreadsheets'],
+      })
+    )
+    migrate({ sheetsService, driveService }, sourceSpreadsheetId).then(
+      newSpreadsheet => {
+        console.log('You can run the command:')
+        console.log(`ID=${newSpreadsheet} make delete-spreadsheet`)
+        console.log('to delete the new spreadsheet.')
+      }
+    )
+    break
+  }
+  default:
+    console.error(
+      `No correspondent migration with "${fromTo}". You can find available options in ${path.resolve(
+        __dirname,
+        'migrate.js'
+      )}`
+    )
+    break
+}

--- a/packages/timeline/makefile
+++ b/packages/timeline/makefile
@@ -16,6 +16,12 @@ dev-server:
 dev-validate:
 	NODE_ENV=production $(ROOT_DIR)/node_modules/.bin/babel-node --root-mode upward "./dev/validate.js"
 
+migrate-spreadsheet:
+	NODE_ENV=production $(ROOT_DIR)/node_modules/.bin/babel-node --root-mode upward "./dev/migrate.js"
+
+delete-spreadsheet:
+	NODE_ENV=production $(ROOT_DIR)/node_modules/.bin/babel-node --root-mode upward "./dev/delete.js"
+
 build: clean build-default
 
 clean:

--- a/packages/timeline/src/migrations/utils/google-services.js
+++ b/packages/timeline/src/migrations/utils/google-services.js
@@ -1,0 +1,40 @@
+import { google } from 'googleapis'
+
+/**
+ *
+ * https://developers.google.com/sheets/api/reference/rest
+ * @export
+ * @param {import('google-auth-library').GoogleAuth} auth
+ * @returns
+ */
+export function sheets(auth) {
+  return google.sheets({
+    version: 'v4',
+    auth,
+  })
+}
+
+/**
+ *
+ * https://developers.google.com/drive/api/v3/reference
+ * @export
+ * @param {import('google-auth-library').GoogleAuth} auth
+ * @returns
+ */
+export function drive(auth) {
+  return google.drive({
+    version: 'v3',
+    auth,
+  })
+}
+
+/**
+ *
+ *
+ * @export
+ * @param {import('google-auth-library').GoogleAuthOptions} authOptions
+ * @returns
+ */
+export function auth(authOptions) {
+  return new google.auth.GoogleAuth(authOptions)
+}

--- a/packages/timeline/src/migrations/v0-to-v2.js
+++ b/packages/timeline/src/migrations/v0-to-v2.js
@@ -1,0 +1,253 @@
+const templateSpreadsheetId = '1f76OLdfZe3kyNOKiPthWNJWVGmY3bkm5KtxB4NYp9uU'
+
+/**
+ *
+ *
+ * @export
+ * @param {object} services
+ * @param {import('googleapis').sheets_v4.Sheets} services.sheetsService
+ * @param {import('googleapis').drive_v3.Drive} services.driveService
+ * @param {string} sourceSpreadsheetId
+ * @param {string} [ownerEmail='developer@twreporter.org'] the owner of new spreadsheet
+ * @return {string} newSpreadsheetId
+ */
+export default async function migrate(
+  { sheetsService, driveService },
+  sourceSpreadsheetId,
+  ownerEmail = 'developer@twreporter.org'
+) {
+  let newSpreadsheetId
+  try {
+    // Get properties of source spreadsheet
+    console.log('Start getting properties from source spreadsheet...')
+    const sourceSpreadsheetProperties = await sheetsService.spreadsheets
+      .get({
+        spreadsheetId: sourceSpreadsheetId,
+        fields: 'properties',
+      })
+      .then(result => result.data.properties)
+    console.log(
+      'Got properties of source spreadsheet. `properties.title`: ' +
+        sourceSpreadsheetProperties.title
+    )
+
+    // Create a new spreadsheet from the template spreadsheet
+    console.log('Start copying template spreadsheet to new spreadsheet...')
+    console.log(
+      `template: https://docs.google.com/spreadsheets/d/${templateSpreadsheetId}`
+    )
+    newSpreadsheetId = await driveService.files
+      .copy({
+        fileId: templateSpreadsheetId,
+        fields: 'id',
+      })
+      .then(result => result.data.id)
+    console.log('The template has been copied to new spreadsheet.')
+    console.log(
+      `new spreadsheet: https://docs.google.com/spreadsheets/d/${newSpreadsheetId}`
+    )
+
+    // Update new spreadsheet with source properties
+    console.log('Start updating properties from source to new spreadsheet')
+    await sheetsService.spreadsheets.batchUpdate({
+      spreadsheetId: newSpreadsheetId,
+      includeSpreadsheetInResponse: false,
+      requestBody: {
+        requests: [
+          {
+            updateSpreadsheetProperties: {
+              properties: {
+                ...sourceSpreadsheetProperties,
+                title: sourceSpreadsheetProperties.title + '(v0->v2)',
+              },
+              fields: '*',
+            },
+          },
+        ],
+      },
+    })
+    console.log('Properties have been updated.')
+
+    // Clear unused data in new spreadsheet
+    console.log('Start clearing template values in new spreadsheet...')
+    await sheetsService.spreadsheets.values.batchClear({
+      spreadsheetId: newSpreadsheetId,
+      ranges: [
+        'elements!B5:B',
+        'elements!C5:C',
+        'elements!D5:D',
+        'elements!E5:E',
+        'elements!F5:F',
+        'elements!G5:G',
+        'elements!H5:H',
+      ],
+    })
+    console.log('Template values have been cleared.')
+
+    // Copy values from source spreadsheet to new one
+    console.log('Start getting values from source spreadsheet')
+    const sourceValues = await sheetsService.spreadsheets.values
+      .batchGet({
+        spreadsheetId: sourceSpreadsheetId,
+        ranges: [
+          // - type
+          '大事記!A4:A',
+          // - label
+          '大事記!B4:B',
+          // - title
+          '大事記!C4:C',
+          // - description
+          '大事記!D4:D',
+          // - image.src
+          '大事記!E4:E',
+          // - image.caption
+          '大事記!F4:F',
+          // - image.alt
+          '大事記!G4:G',
+        ],
+        majorDimension: 'COLUMNS',
+      })
+      .then(result => result.data.valueRanges)
+    console.log('Values of source spreadsheet fetched.')
+    console.log('Start updating source values to new spreadsheet...')
+    await sheetsService.spreadsheets.values.batchUpdate({
+      spreadsheetId: newSpreadsheetId,
+      requestBody: {
+        valueInputOption: 'RAW',
+        data: [
+          // - type
+          {
+            range: 'elements!B5',
+            majorDimension: 'COLUMNS',
+            values: sourceValues[0].values,
+          },
+          // - label
+          {
+            range: 'elements!C5',
+            majorDimension: 'COLUMNS',
+            values: sourceValues[1].values,
+          },
+          // - title
+          {
+            range: 'elements!D5',
+            majorDimension: 'COLUMNS',
+            values: sourceValues[2].values,
+          },
+          // - description
+          {
+            range: 'elements!E5',
+            majorDimension: 'COLUMNS',
+            values: sourceValues[3].values,
+          },
+          // - image.src
+          {
+            range: 'elements!F5',
+            majorDimension: 'COLUMNS',
+            values: sourceValues[4].values,
+          },
+          // - image.caption
+          {
+            range: 'elements!G5',
+            majorDimension: 'COLUMNS',
+            values: sourceValues[5].values,
+          },
+          // - image.alt
+          {
+            range: 'elements!H5',
+            majorDimension: 'COLUMNS',
+            values: sourceValues[6].values,
+          },
+        ],
+        includeValuesInResponse: false,
+      },
+    })
+    console.log('Values updated.')
+    console.log('Start replacing values in new spreadsheet...')
+    const elementsSheetId = await sheetsService.spreadsheets
+      .get({
+        spreadsheetId: newSpreadsheetId,
+        fields: 'sheets',
+      })
+      .then(
+        result =>
+          result.data.sheets.find(
+            sheet => sheet.properties.title === 'elements'
+          ).properties.sheetId
+      )
+    await sheetsService.spreadsheets.batchUpdate({
+      spreadsheetId: newSpreadsheetId,
+      includeSpreadsheetInResponse: false,
+      requestBody: {
+        requests: [
+          {
+            findReplace: {
+              find: 'record-flag',
+              replacement: 'unit-flag',
+              range: {
+                // range: 'elements!B5:B'
+                sheetId: elementsSheetId,
+                startRowIndex: 4,
+                startColumnIndex: 1,
+                endColumnIndex: 2,
+              },
+            },
+          },
+        ],
+      },
+    })
+    console.log('Values have been updated.')
+
+    // Update new spreadsheet permission
+    console.log('Start creating permissions of new spreadsheet...')
+    await driveService.permissions.create({
+      fileId: newSpreadsheetId,
+      requestBody: {
+        role: 'writer',
+        type: 'domain',
+        domain: 'twreporter.org',
+      },
+    })
+    await driveService.permissions.create({
+      fileId: newSpreadsheetId,
+      requestBody: {
+        role: 'commenter',
+        type: 'anyone',
+      },
+    })
+    // Ownership can only be transferred to another user in the same domain as the current owner.
+    // So we cannot transfer ownership to other users as followed code if using service account as spreadsheet creator:
+    // ```
+    // await driveService.permissions.create({
+    //   fileId: newSpreadsheetId,
+    //   transferOwnership: true,
+    //   requestBody: {
+    //     role: 'owner',
+    //     type: 'user',
+    //     emailAddress: ownerEmail,
+    //     emailMessage: 'This spreadsheet is produced by @twreporter/timeline migration tools. Version: v0-to-v2. '
+    //       + `new template: https://docs.google.com/spreadsheets/d/${templateSpreadsheetId} `
+    //       + `source: https://docs.google.com/spreadsheets/d/${sourceSpreadsheetId}`
+    //   }
+    // })
+    // ```
+    // TODO: Use OAuth to use user's authentication to create the file instead.
+    console.log('Permissions updated.')
+  } catch (error) {
+    console.error(error)
+    console.log(
+      'An error occurred when migrating. Trying to delete the new spreadsheet...'
+    )
+    await driveService.files.delete({
+      fileId: newSpreadsheetId,
+    })
+    console.log('New spreadsheet has been deleted.')
+  }
+  console.log('Migration succeeded.')
+  console.log(
+    `source spreadsheet: https://docs.google.com/spreadsheets/d/${sourceSpreadsheetId}`
+  )
+  console.log(
+    `new spreadsheet: https://docs.google.com/spreadsheets/d/${newSpreadsheetId}`
+  )
+  return newSpreadsheetId
+}

--- a/packages/timeline/src/migrations/v0-to-v2.js
+++ b/packages/timeline/src/migrations/v0-to-v2.js
@@ -89,6 +89,8 @@ export default async function migrate(
     const sourceValues = await sheetsService.spreadsheets.values
       .batchGet({
         spreadsheetId: sourceSpreadsheetId,
+        valueRenderOption: 'FORMATTED_VALUE',
+        majorDimension: 'COLUMNS',
         ranges: [
           // - type
           '大事記!A4:A',
@@ -105,7 +107,6 @@ export default async function migrate(
           // - image.alt
           '大事記!G4:G',
         ],
-        majorDimension: 'COLUMNS',
       })
       .then(result => result.data.valueRanges)
     console.log('Values of source spreadsheet fetched.')
@@ -113,7 +114,7 @@ export default async function migrate(
     await sheetsService.spreadsheets.values.batchUpdate({
       spreadsheetId: newSpreadsheetId,
       requestBody: {
-        valueInputOption: 'RAW',
+        valueInputOption: 'USER_ENTERED',
         data: [
           // - type
           {

--- a/packages/timeline/src/migrations/v0-to-v2.js
+++ b/packages/timeline/src/migrations/v0-to-v2.js
@@ -92,19 +92,19 @@ export default async function migrate(
         valueRenderOption: 'FORMATTED_VALUE',
         majorDimension: 'COLUMNS',
         ranges: [
-          // - type
+          // - 0 type
           '大事記!A4:A',
-          // - label
+          // - 1 label
           '大事記!B4:B',
-          // - title
+          // - 2 title
           '大事記!C4:C',
-          // - description
+          // - 3 description
           '大事記!D4:D',
-          // - image.src
+          // - 4 image.caption
           '大事記!E4:E',
-          // - image.caption
+          // - 5 image.src
           '大事記!F4:F',
-          // - image.alt
+          // - 6 image.alt
           '大事記!G4:G',
         ],
       })
@@ -122,37 +122,37 @@ export default async function migrate(
             majorDimension: 'COLUMNS',
             values: sourceValues[0].values,
           },
-          // - label
+          // - content.label
           {
             range: 'elements!C5',
             majorDimension: 'COLUMNS',
             values: sourceValues[1].values,
           },
-          // - title
+          // - content.title
           {
             range: 'elements!D5',
             majorDimension: 'COLUMNS',
             values: sourceValues[2].values,
           },
-          // - description
+          // - content.description
           {
             range: 'elements!E5',
             majorDimension: 'COLUMNS',
             values: sourceValues[3].values,
           },
-          // - image.src
+          // - content.image.src
           {
             range: 'elements!F5',
             majorDimension: 'COLUMNS',
-            values: sourceValues[4].values,
+            values: sourceValues[5].values,
           },
-          // - image.caption
+          // - content.image.caption
           {
             range: 'elements!G5',
             majorDimension: 'COLUMNS',
-            values: sourceValues[5].values,
+            values: sourceValues[4].values,
           },
-          // - image.alt
+          // - content.image.alt
           {
             range: 'elements!H5',
             majorDimension: 'COLUMNS',


### PR DESCRIPTION
Add tools for migration spreadsheet if table schema changed.

Example:

new template (v2): https://docs.google.com/spreadsheets/d/1f76OLdfZe3kyNOKiPthWNJWVGmY3bkm5KtxB4NYp9uU

source spreadsheet (v0): https://docs.google.com/spreadsheets/d/1HTLluTf9LYu4331iRJhUucUHu6KyUOxF4vuSbLXKhjY

new spreadsheet with source content(v2): https://docs.google.com/spreadsheets/d/1XQPKY8Hiwy3cszqGK12gz_2kMfxXRsN5gmjkjzgr3YQ
