### PR TITLE
feat(dual-channel): add full-width wrapper to dual-channel

### DIFF
--- a/packages/dual-channel/dev/client-entry.js
+++ b/packages/dual-channel/dev/client-entry.js
@@ -4,6 +4,7 @@ import { hot } from 'react-hot-loader'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import Root from '../src/app'
+import FullWidthWrapper from '../src/build-code/full-width-wrapper'
 
 const reactRootId = 'root'
 
@@ -13,6 +14,8 @@ const embeddedItems = window.__embeddedItems
 const HotLoaderRoot = hot(module)(Root)
 
 ReactDOM.render(
-  <HotLoaderRoot chapters={chapters} embeddedItems={embeddedItems} />,
+  <FullWidthWrapper full>
+    <HotLoaderRoot chapters={chapters} embeddedItems={embeddedItems} />
+  </FullWidthWrapper>,
   document.getElementById(reactRootId)
 )

--- a/packages/dual-channel/dev/client-entry.js
+++ b/packages/dual-channel/dev/client-entry.js
@@ -14,7 +14,7 @@ const embeddedItems = window.__embeddedItems
 const HotLoaderRoot = hot(module)(Root)
 
 ReactDOM.render(
-  <FullWidthWrapper full>
+  <FullWidthWrapper isFullWidth>
     <HotLoaderRoot chapters={chapters} embeddedItems={embeddedItems} />
   </FullWidthWrapper>,
   document.getElementById(reactRootId)

--- a/packages/dual-channel/dev/webpack.config.js
+++ b/packages/dual-channel/dev/webpack.config.js
@@ -22,6 +22,7 @@ module.exports = {
         test: /\.jsx?$/,
         include: [
           path.resolve(__dirname, '../src/app'),
+          path.resolve(__dirname, '../src/build-code/full-width-wrapper.js'),
           path.resolve(__dirname, './client-entry.js'),
         ],
         use: {

--- a/packages/dual-channel/src/app/components/root.js
+++ b/packages/dual-channel/src/app/components/root.js
@@ -33,7 +33,7 @@ const store = init({
 
 const Container = styled.div`
   background-color: #f1f1f1;
-
+  text-align: left;
   svg text,
   svg text > tspan {
     font-family: 'source-han-sans-traditional', 'Noto Sans TC', 'PingFang TC',

--- a/packages/dual-channel/src/build-code/client.js
+++ b/packages/dual-channel/src/build-code/client.js
@@ -1,6 +1,6 @@
 import buildConst from './constants'
-import PropTypes from 'prop-types'
-import React, { useState, useEffect, useRef } from 'react'
+import FullWidthWrapper from './full-width-wrapper'
+import React from 'react'
 import ReactDOM from 'react-dom'
 import RootReactComponent from '../app'
 // lodash
@@ -15,95 +15,6 @@ const _ = {
 const namespace = buildConst.namespace
 const pkg = buildConst.pkgName
 const dataArr = _.get(window, [namespace, pkg], [])
-
-function getBodyWidth() {
-  if (document.body) {
-    const bodyWidth =
-      document.body.getBoundingClientRect().width || document.body.offsetWidth
-    return bodyWidth || 0
-  }
-  return 0
-}
-
-function useBodyWidth() {
-  const [bodyWidth, setBodyWidth] = useState(getBodyWidth)
-  const handleResize = _.debounce(() => {
-    setBodyWidth(getBodyWidth())
-  }, 400)
-  useEffect(() => {
-    if (window && typeof window.addEventListener === 'function') {
-      window.addEventListener('resize', handleResize)
-      return () => window.removeEventListener('resize', handleResize)
-    }
-  }, [])
-  return bodyWidth
-}
-
-/**
- *
- *
- * @param {HTMLElement} element
- * @returns {number}
- */
-function getXOffset(element) {
-  if (element) {
-    return element.offsetLeft || 0
-  }
-  return 0
-}
-
-/**
- *
- *
- * @param {import('react').MutableRefObject} elementRef
- * @returns
- */
-function useXOffset(elementRef) {
-  const [xOffset, setXPosition] = useState(getXOffset(elementRef.current))
-  const handleResize = _.debounce(() => {
-    setXPosition(getXOffset(elementRef.current))
-  }, 400)
-  useEffect(() => {
-    if (window && typeof window.addEventListener === 'function') {
-      window.addEventListener('resize', handleResize)
-      return () => window.removeEventListener('resize', handleResize)
-    }
-  }, [])
-  return xOffset
-}
-
-function FullWidthWrapper(props) {
-  const { full, children } = props
-  if (!full) {
-    return children
-  }
-  const defaultWidth = '95vw'
-  const defaultXOffset = 0
-  const bodyWidth = useBodyWidth()
-  const wrapper = useRef()
-  const xOffset = useXOffset(wrapper)
-  return (
-    <div
-      ref={wrapper}
-      style={{
-        width: bodyWidth ? `${bodyWidth}px` : defaultWidth,
-        position: 'relative',
-        left: xOffset ? `${xOffset * -1}px` : defaultXOffset,
-      }}
-    >
-      {children}
-    </div>
-  )
-}
-
-FullWidthWrapper.propTypes = {
-  full: PropTypes.bool,
-  children: PropTypes.node,
-}
-
-FullWidthWrapper.defaultProps = {
-  full: true,
-}
 
 if (Array.isArray(dataArr) && dataArr.length > 0) {
   // select first data to render and

--- a/packages/dual-channel/src/build-code/client.js
+++ b/packages/dual-channel/src/build-code/client.js
@@ -1,10 +1,14 @@
-import React from 'react'
+import buildConst from './constants'
+import PropTypes from 'prop-types'
+import React, { useState, useEffect, useRef } from 'react'
 import ReactDOM from 'react-dom'
 import RootReactComponent from '../app'
+// lodash
+import debounce from 'lodash/debounce'
 import get from 'lodash/get'
-import buildConst from './constants'
 
 const _ = {
+  debounce,
   get,
 }
 
@@ -12,14 +16,105 @@ const namespace = buildConst.namespace
 const pkg = buildConst.pkgName
 const dataArr = _.get(window, [namespace, pkg], [])
 
+function getBodyWidth() {
+  if (document.body) {
+    const bodyWidth =
+      document.body.getBoundingClientRect().width || document.body.offsetWidth
+    return bodyWidth || 0
+  }
+  return 0
+}
+
+function useBodyWidth() {
+  const [bodyWidth, setBodyWidth] = useState(getBodyWidth)
+  const handleResize = _.debounce(() => {
+    setBodyWidth(getBodyWidth())
+  }, 400)
+  useEffect(() => {
+    if (window && typeof window.addEventListener === 'function') {
+      window.addEventListener('resize', handleResize)
+      return () => window.removeEventListener('resize', handleResize)
+    }
+  }, [])
+  return bodyWidth
+}
+
+/**
+ *
+ *
+ * @param {HTMLElement} element
+ * @returns {number}
+ */
+function getXOffset(element) {
+  if (element) {
+    return element.offsetLeft || 0
+  }
+  return 0
+}
+
+/**
+ *
+ *
+ * @param {import('react').MutableRefObject} elementRef
+ * @returns
+ */
+function useXOffset(elementRef) {
+  const [xOffset, setXPosition] = useState(getXOffset(elementRef.current))
+  const handleResize = _.debounce(() => {
+    setXPosition(getXOffset(elementRef.current))
+  }, 400)
+  useEffect(() => {
+    if (window && typeof window.addEventListener === 'function') {
+      window.addEventListener('resize', handleResize)
+      return () => window.removeEventListener('resize', handleResize)
+    }
+  }, [])
+  return xOffset
+}
+
+function FullWidthWrapper(props) {
+  const { full, children } = props
+  if (!full) {
+    return children
+  }
+  const defaultWidth = '95vw'
+  const defaultXOffset = 0
+  const bodyWidth = useBodyWidth()
+  const wrapper = useRef()
+  const xOffset = useXOffset(wrapper)
+  return (
+    <div
+      ref={wrapper}
+      style={{
+        width: bodyWidth ? `${bodyWidth}px` : defaultWidth,
+        position: 'relative',
+        left: xOffset ? `${xOffset * -1}px` : defaultXOffset,
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+
+FullWidthWrapper.propTypes = {
+  full: PropTypes.bool,
+  children: PropTypes.node,
+}
+
+FullWidthWrapper.defaultProps = {
+  full: true,
+}
+
 if (Array.isArray(dataArr) && dataArr.length > 0) {
   // select first data to render and
   // removes it from data array
   const data = dataArr.shift()
-  const { uuid, chapters, embeddedItems } = data
+  const { uuid, chapters, embeddedItems, fullWidth } = data
 
   ReactDOM.render(
-    <RootReactComponent chapters={chapters} embeddedItems={embeddedItems} />,
+    <FullWidthWrapper full={fullWidth}>
+      <RootReactComponent chapters={chapters} embeddedItems={embeddedItems} />
+    </FullWidthWrapper>,
     document.getElementById(uuid)
   )
 }

--- a/packages/dual-channel/src/build-code/client.js
+++ b/packages/dual-channel/src/build-code/client.js
@@ -4,11 +4,9 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import RootReactComponent from '../app'
 // lodash
-import debounce from 'lodash/debounce'
 import get from 'lodash/get'
 
 const _ = {
-  debounce,
   get,
 }
 

--- a/packages/dual-channel/src/build-code/client.js
+++ b/packages/dual-channel/src/build-code/client.js
@@ -18,10 +18,10 @@ if (Array.isArray(dataArr) && dataArr.length > 0) {
   // select first data to render and
   // removes it from data array
   const data = dataArr.shift()
-  const { uuid, chapters, embeddedItems, fullWidth } = data
+  const { uuid, chapters, embeddedItems, isFullWidth } = data
 
   ReactDOM.render(
-    <FullWidthWrapper full={fullWidth}>
+    <FullWidthWrapper isFullWidth={isFullWidth}>
       <RootReactComponent chapters={chapters} embeddedItems={embeddedItems} />
     </FullWidthWrapper>,
     document.getElementById(uuid)

--- a/packages/dual-channel/src/build-code/full-width-wrapper.js
+++ b/packages/dual-channel/src/build-code/full-width-wrapper.js
@@ -44,9 +44,9 @@ const defaultWidth = '95vw'
 const defaultXRelatedToViewport = 0
 
 export default function FullWidthWrapper(props) {
-  const { full, children } = props
+  const { isFullWidth, children } = props
 
-  if (!full) {
+  if (!isFullWidth) {
     return children
   }
 
@@ -92,11 +92,11 @@ export default function FullWidthWrapper(props) {
 }
 
 FullWidthWrapper.propTypes = {
-  full: PropTypes.bool,
+  isFullWidth: PropTypes.bool,
   children: PropTypes.node,
 }
 
 FullWidthWrapper.defaultProps = {
-  full: true,
+  isFullWidth: true,
   children: null,
 }

--- a/packages/dual-channel/src/build-code/full-width-wrapper.js
+++ b/packages/dual-channel/src/build-code/full-width-wrapper.js
@@ -63,12 +63,15 @@ export default function FullWidthWrapper(props) {
     wrapperRef.current = node
   }, [])
 
-  const handleResize = _.debounce(() => {
-    const viewportWidth = getViewportWidth()
-    const xRelatedToViewport = getXRelatedToViewport(wrapperRef.current)
-    setViewportWidth(viewportWidth)
-    setXRelatedToViewport(xRelatedToViewport)
-  }, 350)
+  const handleResize = useCallback(
+    _.debounce(() => {
+      const viewportWidth = getViewportWidth()
+      const xRelatedToViewport = getXRelatedToViewport(wrapperRef.current)
+      setViewportWidth(viewportWidth)
+      setXRelatedToViewport(xRelatedToViewport)
+    }, 350),
+    [wrapperRef.current]
+  )
 
   useEffect(() => {
     if (window && typeof window.addEventListener === 'function') {

--- a/packages/dual-channel/src/build-code/full-width-wrapper.js
+++ b/packages/dual-channel/src/build-code/full-width-wrapper.js
@@ -1,0 +1,100 @@
+import PropTypes from 'prop-types'
+import React, { useState, useEffect, useRef } from 'react'
+// lodash
+import debounce from 'lodash/debounce'
+
+const _ = {
+  debounce,
+}
+
+function getViewportWidth() {
+  if (document && document.documentElement) {
+    return document.documentElement.clientWidth || 0
+  }
+  return 0
+}
+
+function useViewportWidth() {
+  const [viewportWidth, setViewportWidth] = useState(getViewportWidth)
+  const handleResize = _.debounce(() => {
+    setViewportWidth(getViewportWidth())
+  }, 400)
+  useEffect(() => {
+    if (window && typeof window.addEventListener === 'function') {
+      window.addEventListener('resize', handleResize)
+      return () => window.removeEventListener('resize', handleResize)
+    }
+  }, [])
+  return viewportWidth
+}
+
+/**
+ * get the offset of the element
+ *
+ * @param {HTMLElement} element
+ * @returns {number}
+ */
+function getXRelatedToViewport(element) {
+  if (element) {
+    return element.getBoundingClientRect().left || 0
+  }
+  return 0
+}
+
+/**
+ *
+ *
+ * @param {import('react').MutableRefObject} elementRef
+ * @returns
+ */
+function useXRelatedToViewport(elementRef) {
+  const elem = elementRef.current || null
+  const [xRelatedToViewport, setXPosition] = useState(
+    getXRelatedToViewport(elem)
+  )
+  const handleResize = _.debounce(() => {
+    setXPosition(getXRelatedToViewport(elem && elem.parentNode))
+  }, 400)
+  useEffect(() => {
+    if (window && typeof window.addEventListener === 'function') {
+      window.addEventListener('resize', handleResize)
+      return () => window.removeEventListener('resize', handleResize)
+    }
+  }, [])
+  return xRelatedToViewport
+}
+
+export default function FullWidthWrapper(props) {
+  const { full, children } = props
+  if (!full) {
+    return children
+  }
+  const defaultWidth = '95vw'
+  const defaultXOffset = 0
+  const viewportWidth = useViewportWidth()
+  const wrapper = useRef()
+  const xRelatedToViewport = useXRelatedToViewport(wrapper)
+  return (
+    <div
+      ref={wrapper}
+      style={{
+        width: viewportWidth ? `${viewportWidth}px` : defaultWidth,
+        position: 'relative',
+        left: xRelatedToViewport
+          ? `${xRelatedToViewport * -1}px`
+          : defaultXOffset,
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+
+FullWidthWrapper.propTypes = {
+  full: PropTypes.bool,
+  children: PropTypes.node,
+}
+
+FullWidthWrapper.defaultProps = {
+  full: true,
+}

--- a/packages/dual-channel/src/build-code/full-width-wrapper.js
+++ b/packages/dual-channel/src/build-code/full-width-wrapper.js
@@ -54,10 +54,12 @@ export default function FullWidthWrapper(props) {
   const [viewportWidth, setViewportWidth] = useState(getViewportWidth)
 
   const wrapperRef = useCallback(node => {
-    const viewportWidth = getViewportWidth()
-    const xRelatedToViewport = getXRelatedToViewport(node)
-    setViewportWidth(viewportWidth)
-    setXRelatedToViewport(xRelatedToViewport)
+    if (node) {
+      const viewportWidth = getViewportWidth()
+      const xRelatedToViewport = getXRelatedToViewport(node)
+      setViewportWidth(viewportWidth)
+      setXRelatedToViewport(xRelatedToViewport)
+    }
     wrapperRef.current = node
   }, [])
 

--- a/packages/dual-channel/src/build-code/full-width-wrapper.js
+++ b/packages/dual-channel/src/build-code/full-width-wrapper.js
@@ -40,7 +40,7 @@ function getXRelatedToViewport(element) {
   return 0
 }
 
-const defaultWidth = '95vw'
+const defaultWidth = 'calc(100vw-17px)' // minus scrollbar width (12~17px in major OSs)
 const defaultXRelatedToViewport = 0
 
 export default function FullWidthWrapper(props) {

--- a/packages/dual-channel/src/build-code/index.js
+++ b/packages/dual-channel/src/build-code/index.js
@@ -16,7 +16,7 @@ const _ = {
  * @param {Object} data - Data for Dual Channel Root React Component
  * @param {Object[]} data.chapters - chapters for Dual Channel Root React Component
  * @param {Object[]} data.embeddedItems - embeddedItems for Dual Channel Root React Component
- * @param {boolean} data.fullWidth - should Dual Channel Component extend to full viewport width
+ * @param {boolean} data.isFullWidth - should Dual Channel Component extend to full viewport width
  * @param {Object} webpackAssets - webpack bundles and chunks
  * @param {string[]} webpackAssets.chunks - webpack common chunks
  * @param {string[]} webpackAssets.bundles - webpack bundles
@@ -28,7 +28,7 @@ export function buildEmbeddedCode(data, webpackAssets) {
   const dataWithUuid = {
     chapters: data.chapters,
     embeddedItems: data.embeddedItems,
-    fullWidth: data.fullWidth,
+    isFullWidth: data.isFullWidth,
     uuid,
   }
 

--- a/packages/dual-channel/src/build-code/index.js
+++ b/packages/dual-channel/src/build-code/index.js
@@ -16,10 +16,11 @@ const _ = {
  * @param {Object} data - Data for Dual Channel Root React Component
  * @param {Object[]} data.chapters - chapters for Dual Channel Root React Component
  * @param {Object[]} data.embeddedItems - embeddedItems for Dual Channel Root React Component
+ * @param {boolean} data.fullWidth - should Dual Channel Component extend to full viewport width
  * @param {Object} webpackAssets - webpack bundles and chunks
  * @param {string[]} webpackAssets.chunks - webpack common chunks
  * @param {string[]} webpackAssets.bundles - webpack bundles
- * @returns {string} embeddec code
+ * @returns {string} embedded code
  */
 export function buildEmbeddedCode(data, webpackAssets) {
   // use uuid to avoid duplication id
@@ -27,6 +28,7 @@ export function buildEmbeddedCode(data, webpackAssets) {
   const dataWithUuid = {
     chapters: data.chapters,
     embeddedItems: data.embeddedItems,
+    fullWidth: data.fullWidth,
     uuid,
   }
 


### PR DESCRIPTION
User can extend the width of `dual-channel` to viewport's width