### PR TITLE
feat(scrollable-image): add full width wrapper

### DIFF
--- a/packages/scrollable-image/dev/test-embedded-code-server.js
+++ b/packages/scrollable-image/dev/test-embedded-code-server.js
@@ -22,9 +22,11 @@ function testEmbeddedCode(embeddedCode) {
           <title>Test Document</title>
         </head>
         <body
-          style="margin:0;font-family: source-han-sans-traditional, Noto Sans TC, PingFang TC, Apple LiGothic Medium, Roboto, Microsoft JhengHei, Lucida Grande, Lucida Sans Unicode, sans-serif;"
+          style="overflow-x:hidden;margin:0;font-family: source-han-sans-traditional, Noto Sans TC, PingFang TC, Apple LiGothic Medium, Roboto, Microsoft JhengHei, Lucida Grande, Lucida Sans Unicode, sans-serif;"
         >
+				<div style="margin-left:100px;">
           ${embeddedCode}
+				</div>
         </body>
       </html>
     `

--- a/packages/scrollable-image/src/build-code/client.js
+++ b/packages/scrollable-image/src/build-code/client.js
@@ -1,3 +1,4 @@
+import FullWidthWrapper from './full-width-wrapper'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import ScrollHorizontal from '../components/scroll-horizontal'
@@ -16,7 +17,9 @@ if (Array.isArray(dataArray) && dataArray.length > 0) {
   const { uuid, data, lazyload } = config
 
   ReactDOM.render(
-    <ScrollHorizontal imgSrc={data} lazyload={lazyload} />,
+    <FullWidthWrapper>
+      <ScrollHorizontal imgSrc={data} lazyload={lazyload} />
+    </FullWidthWrapper>,
     document.getElementById(uuid)
   )
 }

--- a/packages/scrollable-image/src/build-code/full-width-wrapper.js
+++ b/packages/scrollable-image/src/build-code/full-width-wrapper.js
@@ -1,0 +1,96 @@
+import PropTypes from 'prop-types'
+import React, { useState, useEffect, useCallback } from 'react'
+// lodash
+import debounce from 'lodash/debounce'
+
+const _ = {
+  debounce,
+}
+
+function getViewportWidth() {
+  if (document && document.documentElement) {
+    return document.documentElement.clientWidth || 0
+  }
+  return 0
+}
+
+/**
+ * get the distance from the element to viewport
+ *
+ * @param {HTMLElement} element
+ * @returns {number}
+ */
+function getXRelatedToViewport(element) {
+  if (element) {
+    const parent = element.parentElement
+    if (!parent) {
+      return element.getBoundingClientRect().left || 0
+    }
+    const parentComputedStyle = window.getComputedStyle(parent)
+    const parentPaddingLeft =
+      parseFloat(parentComputedStyle.getPropertyValue('padding-left')) || 0
+    const parentBorderLeft =
+      parseFloat(parentComputedStyle.getPropertyValue('border-left')) || 0
+    return (
+      parent.getBoundingClientRect().left +
+        parentPaddingLeft +
+        parentBorderLeft || 0
+    )
+  }
+  return 0
+}
+
+const defaultWidth = '95vw'
+const defaultXRelatedToViewport = 0
+
+export default function FullWidthWrapper(props) {
+  const { children } = props
+
+  const [xRelatedToViewport, setXRelatedToViewport] = useState(0)
+  const [viewportWidth, setViewportWidth] = useState(getViewportWidth)
+
+  const wrapperRef = useCallback(node => {
+    const viewportWidth = getViewportWidth()
+    const xRelatedToViewport = getXRelatedToViewport(node)
+    setViewportWidth(viewportWidth)
+    setXRelatedToViewport(xRelatedToViewport)
+    wrapperRef.current = node
+  }, [])
+
+  const handleResize = _.debounce(() => {
+    const viewportWidth = getViewportWidth()
+    const xRelatedToViewport = getXRelatedToViewport(wrapperRef.current)
+    setViewportWidth(viewportWidth)
+    setXRelatedToViewport(xRelatedToViewport)
+  }, 350)
+
+  useEffect(() => {
+    if (window && typeof window.addEventListener === 'function') {
+      window.addEventListener('resize', handleResize)
+      return () => window.removeEventListener('resize', handleResize)
+    }
+  }, [])
+
+  return (
+    <div
+      ref={wrapperRef}
+      style={{
+        width: viewportWidth ? `${viewportWidth}px` : defaultWidth,
+        position: 'relative',
+        left: xRelatedToViewport
+          ? `${xRelatedToViewport * -1}px`
+          : defaultXRelatedToViewport,
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+
+FullWidthWrapper.propTypes = {
+  children: PropTypes.node,
+}
+
+FullWidthWrapper.defaultProps = {
+  children: null,
+}

--- a/packages/scrollable-image/src/build-code/full-width-wrapper.js
+++ b/packages/scrollable-image/src/build-code/full-width-wrapper.js
@@ -50,11 +50,13 @@ export default function FullWidthWrapper(props) {
   const [viewportWidth, setViewportWidth] = useState(getViewportWidth)
 
   const wrapperRef = useCallback(node => {
-    const viewportWidth = getViewportWidth()
-    const xRelatedToViewport = getXRelatedToViewport(node)
-    setViewportWidth(viewportWidth)
-    setXRelatedToViewport(xRelatedToViewport)
-    wrapperRef.current = node
+    if (node) {
+      const viewportWidth = getViewportWidth()
+      const xRelatedToViewport = getXRelatedToViewport(node)
+      setViewportWidth(viewportWidth)
+      setXRelatedToViewport(xRelatedToViewport)
+      wrapperRef.current = node
+    }
   }, [])
 
   const handleResize = _.debounce(() => {

--- a/packages/scrollable-image/src/build-code/full-width-wrapper.js
+++ b/packages/scrollable-image/src/build-code/full-width-wrapper.js
@@ -59,14 +59,15 @@ export default function FullWidthWrapper(props) {
     }
   }, [])
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const handleResize = useCallback(
     _.debounce(() => {
       const viewportWidth = getViewportWidth()
       const xRelatedToViewport = getXRelatedToViewport(wrapperRef.current)
       setViewportWidth(viewportWidth)
       setXRelatedToViewport(xRelatedToViewport)
-    }, 350),
-    [wrapperRef.current]
+    }, 300),
+    [wrapperRef]
   )
 
   useEffect(() => {
@@ -74,7 +75,7 @@ export default function FullWidthWrapper(props) {
       window.addEventListener('resize', handleResize)
       return () => window.removeEventListener('resize', handleResize)
     }
-  }, [])
+  }, [handleResize])
 
   return (
     <div

--- a/packages/scrollable-image/src/build-code/full-width-wrapper.js
+++ b/packages/scrollable-image/src/build-code/full-width-wrapper.js
@@ -59,12 +59,15 @@ export default function FullWidthWrapper(props) {
     }
   }, [])
 
-  const handleResize = _.debounce(() => {
-    const viewportWidth = getViewportWidth()
-    const xRelatedToViewport = getXRelatedToViewport(wrapperRef.current)
-    setViewportWidth(viewportWidth)
-    setXRelatedToViewport(xRelatedToViewport)
-  }, 350)
+  const handleResize = useCallback(
+    _.debounce(() => {
+      const viewportWidth = getViewportWidth()
+      const xRelatedToViewport = getXRelatedToViewport(wrapperRef.current)
+      setViewportWidth(viewportWidth)
+      setXRelatedToViewport(xRelatedToViewport)
+    }, 350),
+    [wrapperRef.current]
+  )
 
   useEffect(() => {
     if (window && typeof window.addEventListener === 'function') {

--- a/packages/scrollable-image/src/build-code/full-width-wrapper.js
+++ b/packages/scrollable-image/src/build-code/full-width-wrapper.js
@@ -40,7 +40,7 @@ function getXRelatedToViewport(element) {
   return 0
 }
 
-const defaultWidth = '95vw'
+const defaultWidth = 'calc(100vw-17px)' // minus scrollbar width (12~17px in major OSs)
 const defaultXRelatedToViewport = 0
 
 export default function FullWidthWrapper(props) {


### PR DESCRIPTION
This PR includes [this change](https://github.com/twreporter/orangutan-monorepo/pull/49) that users can extend the embedded component width to viewport's width, not to be limited by its parent. 

It has been tested on staging cloud function: https://asia-east2-cloud-functions-268910.cloudfunctions.net/scrollable-image

And can be viewed in this post: https://keystone-preview.twreporter.org/a/test-scrollableimage

Thanks to @YuCJ 's effort.