### PR TITLE
style(dual-channel): restrict mobile embedded item height less than 50vh

### DIFF
--- a/packages/dual-channel/src/app/components/embedded-items/index.js
+++ b/packages/dual-channel/src/app/components/embedded-items/index.js
@@ -71,8 +71,8 @@ const Container = styled.div`
   ${mq.tabletBelow`
     z-index: ${styles.zIndex.embeddedItem};
     width: ${mockup.itemWidth.mobile};
-    ${props =>
-      props.sectionsPosition !== Waypoint.inside ? '' : `padding-bottom: 100%`};
+    height: ${props =>
+      props.sectionsPosition !== Waypoint.inside ? '0' : '50vh'};
     position: fixed;
     top: 0;
     left: 0;
@@ -142,7 +142,21 @@ const ItemAnimationWrapper = styled.div`
   ${mq.tabletBelow`
     text-align: center;
     background-color: #f1f1f1;
+
+    /* default styles for img embedded items */
+    /* users can overwrite these styles in the spreadsheet */
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+      object-position: center;
+    }
+
   `}
+
+  img {
+    width: 100%;
+  }
 `
 
 function SectionItem(props) {

--- a/packages/dual-channel/src/app/components/root.js
+++ b/packages/dual-channel/src/app/components/root.js
@@ -73,6 +73,15 @@ const FirstEmbeddedItem = styled.div`
     height: 50vh;
     width: 100%;
     text-align: center;
+
+    /* default styles for img embedded items */
+    /* users can overwrite these styles in the spreadsheet */
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+      object-position: center;
+    }
   `}
 
   ${mq.desktopOnly`
@@ -88,6 +97,10 @@ const FirstEmbeddedItem = styled.div`
   > div {
     width: 100%;
     height: 100%;
+  }
+
+  img {
+    width: 100%;
   }
 `
 


### PR DESCRIPTION
This is a quick fix because of users' complaints (see https://www.facebook.com/twreporter/posts/2636471363267386).

I already released this change in `@twreporter/dual-channel@2.1.1-beta.3`,  and deployed `@twreporter/dual-channel@2.1.1-beta.3` in latest cloud function.

Create this PR for further discussion.
