### PR TITLE
fix(dual-channel): fix mobile embedded items not show

### DIFF
--- a/packages/dual-channel/src/app/components/embedded-items/index.js
+++ b/packages/dual-channel/src/app/components/embedded-items/index.js
@@ -131,7 +131,10 @@ const ItemAnimationWrapper = styled.div`
       }
       case 'none':
       default: {
-        return ''
+        return css`
+          opacity: ${props =>
+            props.isFocused || props.isPrevious ? '100' : '0'};
+        `
       }
     }
   }}


### PR DESCRIPTION
There are empty embedded items (only render grey container) in mobile when
animation field(圖片動畫效果) is blank in spreadsheet.