### PR TITLE
Several updates of sheet2code-ui

### DIFF
--- a/packages/sheet2code-ui/README.md
+++ b/packages/sheet2code-ui/README.md
@@ -36,7 +36,7 @@ ReactDOM.render(<BuildCodeUI.Component />, document.getElementById('root'))
  *
  *
  * @export
- * @param {*} props
+ * @param {Object} props
  * @param {string} props.codeLabel -The label of form text field for result code
  * @param {string} props.codePathInAxiosResponse - The path to the returned code string in axios response
  * @param {string[]} props.description - The description of the form

--- a/packages/sheet2code-ui/README.md
+++ b/packages/sheet2code-ui/README.md
@@ -32,21 +32,44 @@ ReactDOM.render(<BuildCodeUI.Component />, document.getElementById('root'))
 #### Props
 
 ```js
+/**
+ *
+ *
+ * @export
+ * @param {*} props
+ * @param {string} props.codeLabel -The label of form text field for result code
+ * @param {string} props.codePathInAxiosResponse - The path to the returned code string in axios response
+ * @param {string[]} props.description - The description of the form
+ * @param {Function} props.errorToClientMessage - The function that take axios response error and give client error message
+ * @param {Function} props.formValuesToRequestConfig - The function that takes form values and returns axios request config
+ * @param {Function} props.getCodeFromAxiosResponse - The function that retrieves code string from axios response
+ * @param {number|'dynamic'} props.nOfSheetFields - Set how many sheet fields showed. 'dynamic' will showed at least one field for sheet.
+ * @param {boolean} props.previewAllowCustomWidth - Should UI contain a customizer of preview width
+ * @param {boolean} props.previewAllowToggleDisplay - Should UI contain a toggle of preview display
+ * @param {boolean} props.previewDefaultDisplay - Default value of displaying preview or not
+ * @param {number} props.previewDefaultWidth - The default width of the preview (percentage related to preview container)
+ * @param {string} props.previewOverflow - The CSS overflow property of preview. Should be one of 'hidden', 'visible', or 'scroll'
+ * @param {string} props.title - The title of the form
+ * @returns
+ */
+
 App.propTypes = {
-  codeLabel: PropTypes.string, // The label of form text field for result code
-  codePathInAxiosResponse: PropTypes.string, // The path to the returned code string in axios response
-  description: PropTypes.arrayOf(PropTypes.string), // The description of the form
-  errorToClientMessage: PropTypes.func.isRequired, // The function that take axios response error and give client error message
-  formValuesToRequestConfig: PropTypes.func.isRequired, // The function that takes form values and returns axios request config
-  getCodeFromAxiosResponse: PropTypes.func, // The function that retrieves code string from axios response
+  codeLabel: PropTypes.string,
+  codePathInAxiosResponse: PropTypes.string,
+  description: PropTypes.arrayOf(PropTypes.string),
+  errorToClientMessage: PropTypes.func.isRequired,
+  formValuesToRequestConfig: PropTypes.func.isRequired,
+  getCodeFromAxiosResponse: PropTypes.func,
   nOfSheetFields: PropTypes.oneOfType([
     PropTypes.oneOf(['dynamic']),
     PropTypes.number,
-  ]), // Set how many sheet fields showed. 'dynamic' will showed at least one field for sheet.
-  previewAllowCustomWidth: PropTypes.bool, // Should UI contain a customizer of preview width
-  previewDefaultWidth: PropTypes.number, // The default width of the preview (percentage related to preview container)
+  ]),
+  previewAllowCustomWidth: PropTypes.bool,
+  previewAllowToggleDisplay: PropTypes.bool,
+  previewDefaultDisplay: PropTypes.bool,
+  previewDefaultWidth: PropTypes.number,
   previewOverflow: PropTypes.oneOf(['hidden', 'visible', 'scroll']),
-  title: PropTypes.string.isRequired, // The title of the form
+  title: PropTypes.string.isRequired,
 }
 
 App.defaultProps = {
@@ -56,11 +79,13 @@ App.defaultProps = {
   errorToClientMessage: error => error.message,
   formValuesToRequestConfig: () => {
     throw Error(
-      'The prop `formValuesToRequestConfig` in @twreporter/sheet2code-ui should be a function. But is undefined.'
+      'The prop `formValuesToRequestConfig` passed to @twreporter/sheet2code-ui should be a function. But is undefined.'
     )
   },
   nOfSheetFields: 'dynamic',
   previewAllowCustomWidth: false,
+  previewAllowToggleDisplay: true,
+  previewDefaultDisplay: false,
   previewDefaultWidth: 100,
   previewOverflow: 'hidden',
   title: 'Sheet2Code',

--- a/packages/sheet2code-ui/src/components/app.js
+++ b/packages/sheet2code-ui/src/components/app.js
@@ -148,7 +148,7 @@ export default function App(props) {
           <Typography variant="h3" component="h1" gutterBottom>
             {title}
           </Typography>
-          <Typography variant="body1" gutterBottom>
+          <Typography variant="body1" component="div" gutterBottom>
             {_.map(description, (p, i) => (
               <p key={i} dangerouslySetInnerHTML={{ __html: p }} />
             ))}

--- a/packages/sheet2code-ui/src/components/app.js
+++ b/packages/sheet2code-ui/src/components/app.js
@@ -109,7 +109,6 @@ export default function App(props) {
           )
         ),
       })
-      console.error('Form values:', formValues)
       return
     }
     return axios(axiosOptions)

--- a/packages/sheet2code-ui/src/components/app.js
+++ b/packages/sheet2code-ui/src/components/app.js
@@ -65,6 +65,8 @@ function codeReducer(state, action) {
  * @param {Function} props.getCodeFromAxiosResponse - The function that retrieves code string from axios response
  * @param {number|'dynamic'} props.nOfSheetFields - Set how many sheet fields showed. 'dynamic' will showed at least one field for sheet.
  * @param {boolean} props.previewAllowCustomWidth - Should UI contain a customizer of preview width
+ * @param {boolean} props.previewAllowToggleDisplay - Should UI contain a toggle of preview display
+ * @param {boolean} props.previewDefaultDisplay - Default value of displaying preview or not
  * @param {number} props.previewDefaultWidth - The default width of the preview (percentage related to preview container)
  * @param {string} props.previewOverflow - The CSS overflow property of preview. Should be one of 'hidden', 'visible', or 'scroll'
  * @param {string} props.title - The title of the form
@@ -85,8 +87,10 @@ export default function App(props) {
     nOfSheetFields,
     title,
     previewAllowCustomWidth,
-    previewOverflow,
+    previewAllowToggleDisplay,
+    previewDefaultDisplay,
     previewDefaultWidth,
+    previewOverflow,
   } = props
 
   const buildCode = formValues => {
@@ -164,10 +168,12 @@ export default function App(props) {
       </Container>
       {codeState.code ? (
         <Preview
-          code={codeState.code}
           allowCustomWidth={previewAllowCustomWidth}
-          overflow={previewOverflow}
+          code={codeState.code}
           defaultWidth={previewDefaultWidth}
+          overflow={previewOverflow}
+          allowToggleDisplay={previewAllowToggleDisplay}
+          defaultDisplay={previewDefaultDisplay}
         />
       ) : null}
     </React.Fragment>
@@ -186,6 +192,8 @@ App.propTypes = {
     PropTypes.number,
   ]),
   previewAllowCustomWidth: PropTypes.bool,
+  previewAllowToggleDisplay: PropTypes.bool,
+  previewDefaultDisplay: PropTypes.bool,
   previewDefaultWidth: PropTypes.number,
   previewOverflow: PropTypes.oneOf(['hidden', 'visible', 'scroll']),
   title: PropTypes.string.isRequired,
@@ -203,6 +211,8 @@ App.defaultProps = {
   },
   nOfSheetFields: 'dynamic',
   previewAllowCustomWidth: false,
+  previewAllowToggleDisplay: true,
+  previewDefaultDisplay: false,
   previewDefaultWidth: 100,
   previewOverflow: 'hidden',
   title: 'Sheet2Code',

--- a/packages/sheet2code-ui/src/components/app.js
+++ b/packages/sheet2code-ui/src/components/app.js
@@ -52,6 +52,24 @@ function codeReducer(state, action) {
   }
 }
 
+/**
+ *
+ *
+ * @export
+ * @param {*} props
+ * @param {string} props.codeLabel -The label of form text field for result code
+ * @param {string} props.codePathInAxiosResponse - The path to the returned code string in axios response
+ * @param {string[]} props.description - The description of the form
+ * @param {Function} props.errorToClientMessage - The function that take axios response error and give client error message
+ * @param {Function} props.formValuesToRequestConfig - The function that takes form values and returns axios request config
+ * @param {Function} props.getCodeFromAxiosResponse - The function that retrieves code string from axios response
+ * @param {number|'dynamic'} props.nOfSheetFields - Set how many sheet fields showed. 'dynamic' will showed at least one field for sheet.
+ * @param {boolean} props.previewAllowCustomWidth - Should UI contain a customizer of preview width
+ * @param {number} props.previewDefaultWidth - The default width of the preview (percentage related to preview container)
+ * @param {string} props.previewOverflow - The CSS overflow property of preview. Should be one of 'hidden', 'visible', or 'scroll'
+ * @param {string} props.title - The title of the form
+ * @returns
+ */
 export default function App(props) {
   const [codeState, dispatchCodeAction] = useReducer(
     codeReducer,
@@ -142,20 +160,20 @@ export default function App(props) {
 }
 
 App.propTypes = {
-  codeLabel: PropTypes.string, // The label of form text field for result code
-  codePathInAxiosResponse: PropTypes.string, // The path to the returned code string in axios response
-  description: PropTypes.arrayOf(PropTypes.string), // The description of the form
-  errorToClientMessage: PropTypes.func.isRequired, // The function that take axios response error and give client error message
-  formValuesToRequestConfig: PropTypes.func.isRequired, // The function that takes form values and returns axios request config
-  getCodeFromAxiosResponse: PropTypes.func, // The function that retrieves code string from axios response
+  codeLabel: PropTypes.string,
+  codePathInAxiosResponse: PropTypes.string,
+  description: PropTypes.arrayOf(PropTypes.string),
+  errorToClientMessage: PropTypes.func.isRequired,
+  formValuesToRequestConfig: PropTypes.func.isRequired,
+  getCodeFromAxiosResponse: PropTypes.func,
   nOfSheetFields: PropTypes.oneOfType([
     PropTypes.oneOf(['dynamic']),
     PropTypes.number,
-  ]), // Set how many sheet fields showed. 'dynamic' will showed at least one field for sheet.
-  previewAllowCustomWidth: PropTypes.bool, // Should UI contain a customizer of preview width
-  previewDefaultWidth: PropTypes.number, // The default width of the preview (percentage related to preview container)
+  ]),
+  previewAllowCustomWidth: PropTypes.bool,
+  previewDefaultWidth: PropTypes.number,
   previewOverflow: PropTypes.oneOf(['hidden', 'visible', 'scroll']),
-  title: PropTypes.string.isRequired, // The title of the form
+  title: PropTypes.string.isRequired,
 }
 
 App.defaultProps = {

--- a/packages/sheet2code-ui/src/components/app.js
+++ b/packages/sheet2code-ui/src/components/app.js
@@ -93,7 +93,22 @@ export default function App(props) {
     dispatchCodeAction({
       type: actionTypes.request,
     })
-    return axios(formValuesToRequestConfig(formValues))
+    let axiosOptions
+    try {
+      axiosOptions = formValuesToRequestConfig(formValues)
+    } catch (error) {
+      dispatchCodeAction({
+        type: actionTypes.fail,
+        errorMessage: errorToClientMessage(
+          new Error(
+            'Failed to build request config from form values: ' + error.message
+          )
+        ),
+      })
+      console.error('Form values:', formValues)
+      return
+    }
+    return axios(axiosOptions)
       .then(axiosRes => {
         const code =
           typeof getCodeFromAxiosResponse === 'function'
@@ -183,7 +198,7 @@ App.defaultProps = {
   errorToClientMessage: error => error.message,
   formValuesToRequestConfig: () => {
     throw Error(
-      'The prop `formValuesToRequestConfig` in @twreporter/sheet2code-ui should be a function. But is undefined.'
+      'The prop `formValuesToRequestConfig` passed to @twreporter/sheet2code-ui should be a function. But is undefined.'
     )
   },
   nOfSheetFields: 'dynamic',

--- a/packages/sheet2code-ui/src/components/app.js
+++ b/packages/sheet2code-ui/src/components/app.js
@@ -56,7 +56,7 @@ function codeReducer(state, action) {
  *
  *
  * @export
- * @param {*} props
+ * @param {Object} props
  * @param {string} props.codeLabel -The label of form text field for result code
  * @param {string} props.codePathInAxiosResponse - The path to the returned code string in axios response
  * @param {string[]} props.description - The description of the form

--- a/packages/sheet2code-ui/src/components/preview.js
+++ b/packages/sheet2code-ui/src/components/preview.js
@@ -30,25 +30,36 @@ const useStyles = makeStyles({
 })
 
 Preview.propTypes = {
-  code: PropTypes.string,
-  defaultWidth: PropTypes.number,
   allowCustomWidth: PropTypes.bool,
+  allowToggleDisplay: PropTypes.bool,
+  code: PropTypes.string,
+  defaultDisplay: PropTypes.bool,
+  defaultWidth: PropTypes.number,
   overflow: PropTypes.oneOf(['hidden', 'visible', 'scroll']),
 }
 
 Preview.defaultProps = {
-  code: '',
-  defaultWidth: 100,
   allowCustomWidth: false,
+  allowToggleDisplay: true,
+  code: '',
+  defaultDisplay: false,
+  defaultWidth: 100,
   overflow: 'hidden',
 }
 
 export default function Preview(props) {
-  const { code, defaultWidth, allowCustomWidth, overflow } = props
+  const {
+    code,
+    defaultWidth,
+    allowCustomWidth,
+    overflow,
+    allowToggleDisplay,
+    defaultDisplay,
+  } = props
   const [embeddedWidth, setEmbeddedWidth] = useState(defaultWidth)
   const embeddedEle = useRef(null)
   const [errorMessage, setErrorMessage] = useState('null')
-  const [display, setDisplay] = useState(false)
+  const [display, setDisplay] = useState(defaultDisplay)
   const styles = useStyles({ embeddedWidth, display, overflow })
   useEffect(() => {
     /*
@@ -87,20 +98,26 @@ export default function Preview(props) {
   return (
     <div className={styles.container}>
       <div style={{ textAlign: 'center' }}>
-        <FormControlLabel
-          className={styles.switch}
-          control={
-            <Switch
-              checked={display}
-              onChange={(event, value) => {
-                setDisplay(value)
-              }}
-              name="display"
-              color="primary"
-            />
-          }
-          label="預覽"
-        />
+        {allowToggleDisplay ? (
+          <FormControlLabel
+            className={styles.switch}
+            control={
+              <Switch
+                checked={display}
+                onChange={(event, value) => {
+                  setDisplay(value)
+                }}
+                name="display"
+                color="primary"
+              />
+            }
+            label="預覽"
+          />
+        ) : (
+          <Typography variant="h3" align="center" color="primary">
+            預覽
+          </Typography>
+        )}
       </div>
       <Typography
         variant="body2"

--- a/packages/sheet2code-ui/src/components/preview.js
+++ b/packages/sheet2code-ui/src/components/preview.js
@@ -114,7 +114,7 @@ export default function Preview(props) {
             label="預覽"
           />
         ) : (
-          <Typography variant="h3" align="center" color="primary">
+          <Typography variant="h4" align="center" color="primary">
             預覽
           </Typography>
         )}


### PR DESCRIPTION
Main updates:

- Fix uncatched error
- Add new props: `previewAllowToggleDisplay` and `previewDefaultDisplay` (For `scrollable-video`. It needs to measure the elements' sizes on mounting. So the elements cannot be hidden on mounting.)
- Fix DOM validation warning of nested p element