### PR TITLE
fix(scrollable-image-ui): set `useBuiltIns` to `entry`

### DIFF
--- a/packages/scrollable-image-ui/webpack.config.js
+++ b/packages/scrollable-image-ui/webpack.config.js
@@ -106,7 +106,7 @@ const config = {
                 '@babel/env',
                 // Config the bundle for browsers
                 {
-                  useBuiltIns: 'usage',
+                  useBuiltIns: 'entry',
                   modules: 'auto',
                   targets: 'last 2 versions, not dead', // Ref: https://github.com/browserslist/browserslist#best-practices
                 },


### PR DESCRIPTION
This patch sets `useBuiltIns` to `entry` for `@babel/polyfill`