### PR TITLE
fix(scrollable-video): add `useCallback` for dependency of `useEffect`

### DIFF
--- a/packages/scrollable-video/src/components/scrollable-video.js
+++ b/packages/scrollable-video/src/components/scrollable-video.js
@@ -193,9 +193,9 @@ export default function ScrollableVideo({
     gsapVersion,
     scrollTriggerVersion,
     pollingTimeout,
-    onCreatingScrollTriggerError: () => {
+    onCreatingScrollTriggerError: useCallback(() => {
       setScrollTriggerError(true)
-    },
+    }, [setScrollTriggerError]),
   })
 
   const syncDOMValues = useCallback(() => {


### PR DESCRIPTION
This patch wraps function dependency (`onCreatingScrollTriggerError`)
of `useEffect` into `useCallback` to ensure it doesn't change on
every render unless its own dependency also changes.