### PR TITLE
chore(scrollable-video): add AbortController polyfill

### DIFF
--- a/packages/scrollable-video/package.json
+++ b/packages/scrollable-video/package.json
@@ -27,6 +27,7 @@
     "uuidv4": "^6.2.0"
   },
   "dependencies": {
+    "abortcontroller-polyfill": "^1.7.1",
     "lodash": "^4.17.15",
     "prop-types": "^15.0.0",
     "react": "^16.8.0",

--- a/packages/scrollable-video/src/build-code/client.js
+++ b/packages/scrollable-video/src/build-code/client.js
@@ -1,3 +1,4 @@
+import 'abortcontroller-polyfill/dist/polyfill-patch-fetch'
 import 'whatwg-fetch'
 import buildConst from './constants'
 import React from 'react'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2786,6 +2786,11 @@ abort-controller@^3.0.0:
   dependencies:
     event-target-shim "^5.0.0"
 
+abortcontroller-polyfill@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.1.tgz#27084bac87d78a7224c8ee78135d05df430c2d2f"
+  integrity sha512-yml9NiDEH4M4p0G4AcPkg8AAa4mF3nfYF28VQxaokpO67j9H7gWgmsVWJ/f1Rn+PzsnDYvzJzWIQzCqDKRvWlA==
+
 accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"


### PR DESCRIPTION
This patch adds AbortController polyfill for abortable fetch(),
especially for legacy version of browsers (e.g. safari 10.2) which
doesn't yet implement AbortController DOM API.

ref: https://github.com/mo/abortcontroller-polyfill