### PR TITLE
chore: remove `packages/orangutan/node_module`s from `save_cache`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,6 @@ commands:
           key: v3-dependencies-link-{{ checksum "packages-checksums" }}
           paths:
             - packages/dual-channel/node_modules
-            - packages/orangutan/node_modules
             - packages/scrollable-image-ui/node_modules
             - packages/scrollable-image/node_modules
             - packages/sheet2code-ui/node_modules


### PR DESCRIPTION
This patch updates config.yml for circleci to remove `packages/orangutan/node_module`s
from `save_cache` since the orangutan sub-packages has been removed.