### PR TITLE
fix: update circle-ci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ commands:
               <<^ parameters.prerelease >>--message "$RELEASE_COMMIT_HEAD"<</ parameters.prerelease >> \
               --yes
             # Push new version commit back to origin/master
-            <<^ parameters.prerelease >>git push origin master<</ parameters.prerelease >>
+            <<^ parameters.prerelease >>git push origin "$CIRCLE_BRANCH":master<</ parameters.prerelease >>
             echo "HEAD after version: $(git log -1 --pretty=format:%H)"
 
   install-deps:


### PR DESCRIPTION
This patch updates circle-ci config to fix an issue where the release
commit on branch 'release' can not be pushed into 'master'.