### PR TITLE
fix(timeline): add missing `;` to avoid `Uncaught SyntaxError`

### DIFF
--- a/packages/timeline/src/build-code/inject-style-script.js
+++ b/packages/timeline/src/build-code/inject-style-script.js
@@ -49,7 +49,7 @@ if (!target) {
     node.innerHTML = '${escape(styleContent)}';
     document.head.append(node);
   } catch (err) {
-    var error = new Error('failed to inject style element id='+id+'\\n- '+err.message)
+    var error = new Error('failed to inject style element id='+id+'\\n- '+err.message);
     console.error(error);
 }}})()</script>
 `


### PR DESCRIPTION
### Bug description:
If we minify the Timeline JavaScript snippet, those multiple lines will
be concatenated into one line code. The missing `;` will cause the
JavaScript `SyntaxError` error.

