### PR TITLE
fix(dual-channel): keep first embedded item unfixed before enter

### DIFF
--- a/packages/dual-channel/src/app/components/embedded-items/index.js
+++ b/packages/dual-channel/src/app/components/embedded-items/index.js
@@ -79,6 +79,8 @@ const ItemViewport = styled.div`
         return `position: static;`
       } else if (props.sectionsPosition === Waypoint.above) {
         return `position: absolute; bottom: 50vh;`
+      } else if (props.sectionsPosition === Waypoint.below) {
+        return `position: absolute; top:0px;`
       }
       return `position: fixed; top: 0px;`
     }}


### PR DESCRIPTION
Address [TWREPORTER-415](https://twreporter-org.atlassian.net/browse/TWREPORTER-415)

Before this patch, first embedded item fixes on top of viewport
before the dual-channel section enters on tablet, mobile devices.

This patch makes the first embedded item be sticked to the top of
the dual-channel section instead of the viewport to keep touch
interactions available and will not be hindered by the fixed
first item.