### PR TITLE
Jason/enable interfaces

### DIFF
--- a/packages/dual-channel/src/app/components/embedded-items/index.js
+++ b/packages/dual-channel/src/app/components/embedded-items/index.js
@@ -81,7 +81,7 @@ const ItemViewport = styled.div`
       } else if (props.sectionsPosition === Waypoint.above) {
         return `position: absolute; bottom: 50vh;`
       } else if (props.sectionsPosition === Waypoint.below) {
-        return `position: absolute; top: ${offsetTop}px;`
+        return `position: absolute; top: 0px;`
       }
       return `position: fixed; top: ${offsetTop}px;`
     }}

--- a/packages/dual-channel/src/app/components/embedded-items/index.js
+++ b/packages/dual-channel/src/app/components/embedded-items/index.js
@@ -7,6 +7,7 @@ import styled, { css } from 'styled-components'
 import mq from '../../utils/media-query'
 import { connect } from 'react-redux'
 import { Waypoint } from 'react-waypoint'
+import { offsetTop } from '../../constants/customized-props'
 
 const _ = {
   get,
@@ -80,9 +81,9 @@ const ItemViewport = styled.div`
       } else if (props.sectionsPosition === Waypoint.above) {
         return `position: absolute; bottom: 50vh;`
       } else if (props.sectionsPosition === Waypoint.below) {
-        return `position: absolute; top:0px;`
+        return `position: absolute; top: ${offsetTop}px;`
       }
-      return `position: fixed; top: 0px;`
+      return `position: fixed; top: ${offsetTop}px;`
     }}
   `}
   ${mq.desktopOnly`

--- a/packages/dual-channel/src/app/components/sections-entry-points.js
+++ b/packages/dual-channel/src/app/components/sections-entry-points.js
@@ -3,6 +3,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { Waypoint } from 'react-waypoint'
 import { connect } from 'react-redux'
+import { scrollableAncestor } from '../constants/customized-props'
 
 const EntryPoint = styled.div`
   width: 1px;
@@ -51,6 +52,7 @@ class _HeadEntryPoint extends React.PureComponent {
   render() {
     return (
       <Waypoint
+        scrollableAncestor={scrollableAncestor}
         topOffset={this.props.topOffset}
         bottomOffset={this.props.bottomOffset}
         onPositionChange={this._handlePositionChange}

--- a/packages/dual-channel/src/app/components/text/index.js
+++ b/packages/dual-channel/src/app/components/text/index.js
@@ -11,6 +11,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { Waypoint } from 'react-waypoint'
 import { connect } from 'react-redux'
+import { scrollableAncestor } from '../../constants/customized-props'
 
 const _ = {
   get,
@@ -110,6 +111,7 @@ class ArticleText extends React.Component {
     const _renderSection = (section, sectionIndex) => {
       const sectionJsx = (
         <Waypoint
+          scrollableAncestor={scrollableAncestor}
           key={section.id}
           id={section.id}
           topOffset="49%"

--- a/packages/dual-channel/src/app/components/text/index.js
+++ b/packages/dual-channel/src/app/components/text/index.js
@@ -67,7 +67,7 @@ class ArticleText extends React.Component {
     chapters: PropTypes.arrayOf(predefinedPropTypes.chapter).isRequired,
     // provided by redux
     // currentAnchor: PropTypes.number.isRequired,
-    updatAnchorIndex: PropTypes.func.isRequired,
+    updateAnchorIndex: PropTypes.func.isRequired,
   }
 
   _handlePositionChange = (
@@ -87,7 +87,7 @@ class ArticleText extends React.Component {
       positionState.previousSection = sectionIndex
     }
 
-    this.props.updatAnchorIndex({
+    this.props.updateAnchorIndex({
       ...positionState,
     })
   }
@@ -142,7 +142,7 @@ class ArticleText extends React.Component {
 }
 
 const mapDispatchToProps = dispatch => ({
-  updatAnchorIndex: dispatch.position.update,
+  updateAnchorIndex: dispatch.position.update,
 })
 
 export default connect(

--- a/packages/dual-channel/src/app/constants/customized-props.js
+++ b/packages/dual-channel/src/app/constants/customized-props.js
@@ -1,12 +1,12 @@
 const isClientSide =
   typeof window !== 'undefined' && typeof window.document !== 'undefined'
 
-let scrollableAncestorValue =
+const scrollableAncestorValue =
   isClientSide &&
   document.currentScript.getAttribute('data-scrollable-ancestor')
 export const scrollableAncestor = scrollableAncestorValue || undefined
 
-let offsetTopValue =
+const offsetTopValue =
   isClientSide && document.currentScript.getAttribute('data-offset-top')
 export const offsetTop =
   offsetTopValue &&

--- a/packages/dual-channel/src/app/constants/customized-props.js
+++ b/packages/dual-channel/src/app/constants/customized-props.js
@@ -1,4 +1,4 @@
 export const scrollableAncestor =
-  document.currentScript.getAttribute('data-scrollableAncestor') || undefined
+  document.currentScript.getAttribute('data-scrollable-ancestor') || undefined
 export const offsetTop =
-  document.currentScript.getAttribute('data-offsetTop') || 0
+  document.currentScript.getAttribute('data-offset-top') || 0

--- a/packages/dual-channel/src/app/constants/customized-props.js
+++ b/packages/dual-channel/src/app/constants/customized-props.js
@@ -1,4 +1,16 @@
-export const scrollableAncestor =
-  document.currentScript.getAttribute('data-scrollable-ancestor') || undefined
+const isClientSide =
+  typeof window !== 'undefined' && typeof window.document !== 'undefined'
+
+let scrollableAncestorValue =
+  isClientSide &&
+  document.currentScript.getAttribute('data-scrollable-ancestor')
+export const scrollableAncestor = scrollableAncestorValue || undefined
+
+let offsetTopValue =
+  isClientSide && document.currentScript.getAttribute('data-offset-top')
 export const offsetTop =
-  document.currentScript.getAttribute('data-offset-top') || 0
+  offsetTopValue &&
+  Number.isInteger(Number(offsetTopValue)) &&
+  Number(offsetTopValue) > 0
+    ? offsetTopValue
+    : 0

--- a/packages/dual-channel/src/app/constants/customized-props.js
+++ b/packages/dual-channel/src/app/constants/customized-props.js
@@ -1,0 +1,4 @@
+export const scrollableAncestor =
+  document.currentScript.getAttribute('data-scrollableAncestor') || undefined
+export const offsetTop =
+  document.currentScript.getAttribute('data-offsetTop') || 0


### PR DESCRIPTION
fix #138 #139, 新增scrollableAncestor/offsetTop options，讓使用者可以調整embed code

option設定方式：在最後一個script tag加入`data-scrollable-ancestor` `data-offset-top`, 

ex:
<script type="text/javascript" crossorigin="" src="/dist/main.a93c58f44676c91d15a5.bundle.js" data-scrollable-ancestor="window" data-offset-top="70"></script>

@nickhsine 我這樣改您覺得ok嗎? 還請幫忙建議, 謝謝!

cc @fzhantw 